### PR TITLE
feat: support IPNS name in URL fragment for sharing

### DIFF
--- a/components/ipns-inspector.tsx
+++ b/components/ipns-inspector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useMachine } from '@xstate/react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -63,6 +63,16 @@ export default function IPNSInspector() {
       : 'inspect'
   const { error } = state.context
 
+  // Prefill IPNS Name from URL fragment on mount to support sharing/bookmarking
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.hash) {
+      const fragment = window.location.hash.substring(1) // Remove the # prefix
+      if (fragment) {
+        send({ type: 'UPDATE_NAME', value: fragment })
+      }
+    }
+  }, [send])
+
   return (
     <Card className="w-full max-w-2xl mx-auto">
       <CardHeader>
@@ -89,7 +99,13 @@ export default function IPNSInspector() {
                     placeholder="k51... or 12D..."
                   />
                   <Button
-                    onClick={() => send({ type: 'INSPECT_NAME' })}
+                    onClick={() => {
+                      send({ type: 'INSPECT_NAME' })
+                      // Update URL fragment to allow sharing/bookmarking the current IPNS name
+                      if (state.context.nameInput) {
+                        window.location.hash = state.context.nameInput
+                      }
+                    }}
                     disabled={
                       isLoading || state.context.nameValidationError || state.context.nameInput?.length === 0
                     }


### PR DESCRIPTION
This PR is a quality of life improvement that allows prefilling IPNS name field from URL hash on page load and update hash when fetching a record to enable sharing and bookmarking specific IPNS names. 

This will also alow us to link to ipns.ipfs.network from check.ipfs.network (if IPNS Name is detected):
- https://github.com/ipfs/ipfs-check/pull/114