### PR TITLE
fix: raise default ttl to 5m, add 1h preset

### DIFF
--- a/components/ipns-inspector.tsx
+++ b/components/ipns-inspector.tsx
@@ -355,6 +355,14 @@ export default function IPNSInspector() {
                   >
                     5 minutes
                   </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      send({ type: 'UPDATE_FORM', field: 'ttlMs', value: (60 * 60 * 1000).toString() })
+                    }
+                  >
+                    1 hour
+                  </Button>
                 </div>
               </div>
 

--- a/lib/ipns-machine.tsx
+++ b/lib/ipns-machine.tsx
@@ -162,7 +162,7 @@ export const ipnsMachine = setup({
     formData: {
       value: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
       lifetime: DEFAULT_LIFETIME_MS,
-      ttlMs: 60 * 1000, // Default TTL of 60 seconds in milliseconds
+      ttlMs: 5 * 60 * 1000, // Default TTL of 5 minutes in milliseconds (matches Kubo's `ipfs name publish --ttl` default)
     },
   },
   on: {


### PR DESCRIPTION
Align the create-form default with Kubo's own `ipfs name publish --ttl` default and add a 1h preset for users who publish infrequently.

- Closes #48